### PR TITLE
Adding pagination support to get resource records.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 dist/
+bin/
+gopath/

--- a/main.go
+++ b/main.go
@@ -46,11 +46,28 @@ func getResourceRecords(profile string, domain string) ([]*route53.ResourceRecor
 	params := &route53.ListResourceRecordSetsInput{
 		HostedZoneId: aws.String(*zone.Id),
 	}
-	resp, err := service.ListResourceRecordSets(params)
-	if err != nil {
-		return nil, err
+
+	var rrsets []*route53.ResourceRecordSet
+
+	for {
+		var resp *route53.ListResourceRecordSetsOutput
+		resp, err = service.ListResourceRecordSets(params)
+
+		if err != nil {
+			return nil, err
+		}
+
+		rrsets = append(rrsets, resp.ResourceRecordSets...)
+		if *resp.IsTruncated {
+			params.StartRecordName = resp.NextRecordName
+			params.StartRecordType = resp.NextRecordType
+			params.StartRecordIdentifier = resp.NextRecordIdentifier
+		} else {
+			break
+		}
 	}
-	return resp.ResourceRecordSets, nil
+
+	return rrsets, nil
 }
 
 func createChanges(domain string, recordSets []*route53.ResourceRecordSet) []*route53.Change {


### PR DESCRIPTION
We noticed that when we had lots of records to transfer over we would only transfer the first 100 records. This change allows pagination of the ListResourceRecordSets command.
