### PR TITLE
Add support for specifying hosted zone id

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # route53copy, copies resource records between two AWS Route53 accounts
 
-`route53copy` copies resource records from one AWS account to another. It
+`route53copy` copies resource records from one AWS account to another (or inside the same account). It
 creates a `ChangeResourceRecordSet` with `UPSERT` for all `ResourceRecord`s of
 the source account and sends it to the destination account.
 
 The top-level `SOA` and `NS` are not included in the change set since they
 should already exist in the destination account.
 
-The domain must already exist in both accounts and [AWS Named Profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)
+The destination domain must already exist in the destination account and [AWS Named Profiles](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-multiple-profiles)
 must be configured for both the source account and the destination account.
 
 
@@ -49,9 +49,11 @@ $ chmod a+x /usr/local/bin/route53copy
 
 ```
 $ route53copy --help
-Usage: route53copy [options] <source_profile> <dest_profile> <domain>
+Usage: route53copy [options] <source_profile> <dest_profile> <source_domain> [dest_domain]
   -dry
         Don't make any changes
+  -exclude value
+        Comma separated list of DNS entries types of the base domain to be ignored. If not set SOA and NS will be excluded. (default [])
   -help
         Show help text
   -version
@@ -59,7 +61,7 @@ Usage: route53copy [options] <source_profile> <dest_profile> <domain>
 ```
 
 ```
-$ route53copy aws_profile1 aws_profile2 example.com
+$ route53copy aws_profile1 aws_profile2 example.com foobar.com
 Number of Records:  55
 53 records in 'example.com' are copied from aws_profile1-dev to aws_profile2
 {
@@ -73,4 +75,3 @@ Number of Records:  55
 ## Release Notes
 
 A list of changes are in the [RELEASE_NOTES](RELEASE_NOTES.md).
-

--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ Usage: route53copy [options] <source_profile> <dest_profile> <source_domain> [de
 ```
 
 ```
-$ route53copy aws_profile1 aws_profile2 example.com foobar.com
+$ route53copy -exclude "SOA,NS,MX" aws_profile1 aws_profile2 example.com foobar.com
+Skipping example.com. NS
+Skipping example.com. SOA
+Skipping example.com. MX
 Number of Records:  55
 53 records in 'example.com' are copied from aws_profile1-dev to aws_profile2
 {

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Skipping example.com. NS
 Skipping example.com. SOA
 Skipping example.com. MX
 Number of Records:  55
-53 records in 'example.com' are copied from aws_profile1-dev to aws_profile2
+52 records in 'example.com' are copied from aws_profile1-dev to aws_profile2
 {
   Comment: "Importing ALL records from aws_profile",
   Id: "/change/C3QI8LAP4H5G9",

--- a/README.md
+++ b/README.md
@@ -49,15 +49,21 @@ $ chmod a+x /usr/local/bin/route53copy
 
 ```
 $ route53copy --help
-Usage: route53copy [options] <source_profile> <dest_profile> <source_domain> [dest_domain]
+
+route53copy [options] <source_profile> <dest_profile> <srcDomain> [destDomain]
   -dry
         Don't make any changes
   -exclude value
-        Comma separated list of DNS entries types of the base domain to be ignored. If not set SOA and NS will be excluded. (default [])
+        Comma separated list of DNS entries types of the base domain to be ignored. If not set SOA and NS will be excluded.
   -help
         Show help text
+  -hosted-zones string
+        Comma separated lsit of hosted-zones for accounts with access limmited to specific hosted zones
+  -show-changes
+        Show change list
   -version
         Show version
+
 ```
 
 ```

--- a/count.js
+++ b/count.js
@@ -1,0 +1,5 @@
+fs = require('fs')
+
+data = fs.readFileSync('dns.json')
+data = JSON.parse(data)
+console.log(data.ResourceRecordSets.length)

--- a/dns.json
+++ b/dns.json
@@ -1,0 +1,4933 @@
+{
+    "ResourceRecordSets": [
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "52.89.176.87"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10 spring.matshost.co.uk."
+                }
+            ], 
+            "Type": "MX", 
+            "Name": "compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ns-1002.awsdns-61.net."
+                }, 
+                {
+                    "Value": "ns-366.awsdns-45.com."
+                }, 
+                {
+                    "Value": "ns-1038.awsdns-01.org."
+                }, 
+                {
+                    "Value": "ns-1678.awsdns-17.co.uk."
+                }
+            ], 
+            "Type": "NS", 
+            "Name": "compligo.com.", 
+            "TTL": 172800
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ns-1002.awsdns-61.net. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"
+                }
+            ], 
+            "Type": "SOA", 
+            "Name": "compligo.com.", 
+            "TTL": 900
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "\\052.compligo.com.", 
+            "TTL": 30
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aadiscount.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aagny-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aagny.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aakre.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aas.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aca.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acc.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acimacredit-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acimacredit.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acmetrucking--sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acmetrucking-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acmetrucking.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acton-08-11-16.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "acton-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "adam.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "aifinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a7d842a4e7dae11e79b4602c04bab068-569647559.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "alertmanager.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "alison.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "allied-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "americanfinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "americanrvcenter.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "amerifinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "andy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "andy1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "andy3.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "aaa98c4e37da611e789ef02133f294c6-1052092164.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "api.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ad82cb5b3bcf511e6ac8c0265842990d-1075185953.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "case.api.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ac1794171bcf511e6ac8c0265842990d-1164925788.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compligo.api.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "aacf1bb5f7da611e789ef02133f294c6-2130931663.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev.api.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "asburypoc-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "asburypoc.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "atlantabest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "auto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "autofocus-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "autofocus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "autonorth.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "avidacceptance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ballweg-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ballweg.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bell-finance-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bell-finance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "beverlyfinancial.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "billharris-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "billharrisaut-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "billharrisauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bob.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobferrandoford.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobkingauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobkingauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobmoore-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobmoore.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobsteelechev-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bobsteelechevy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "bram.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "brenden.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "brian-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "brian.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "brinkfleet.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "brownbagjune.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "buddygregg.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "burnsvillemotors.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "buxman.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "byers.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "byersauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "car-mart-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "car-mart.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cardinal.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "carpros.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cashco-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cashtyme.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cassillmotors.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cfsnow.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cgcontrol.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cgscheduler.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ch7test.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "champions.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "championsyamaha.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "chaprell.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "chicagomotorcars.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "chicoauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "christain.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "aca95698e7db511e79b4602c04bab068-2040809992.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "chronograf.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "classictrak.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "clonetest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.10.10.10"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "cluster.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "columbineford.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "com-40.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "communityhonda.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complaints-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complaints.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compli-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compli.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compliauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compliclean.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complicontroller.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complidev1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complifinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a58d7f7bcb1d011e69a2902f14197c1f-734688567.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compligo-api.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "compligo1test.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complihost2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complihost3-uat.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complihost3.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ec2-34-208-45-206.us-west-2.compute.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complinator.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complix.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "complix2.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "conbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "concourse-web-912142814.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "concourse.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "controllertest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cooper.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cooperauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cooperauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cotruck-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cotruck.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cowboydodge.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "cox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "creager-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "creager.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "crmpm.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "csm.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "curryauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "curryauto-sb2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "curryauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "custommarine.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dan.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dartco-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "daseke.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dave.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "david.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "david1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "david2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "davidchrysler.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dawsonmarine.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dealerworld.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "demo-phase4.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "demo10.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "demo5-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "demo5.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidemos.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "demo9.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "deploy-owen2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-controller.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-cvs.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-db.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a740525e3e8b111e69e8e02c82bb19d6-1508171953.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-adam.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a74552fdee8b111e69e8e02c82bb19d6-1695805005.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-andy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a746718dee8b111e69e8e02c82bb19d6-1252291061.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-david.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ab1d75f1ae8a711e69e8e02c82bb19d6-363142642.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-http.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a743ca5bee8b111e69e8e02c82bb19d6-960439354.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-schenn.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a73eafd46e8b111e69e8e02c82bb19d6-1082540082.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-shane.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a73d8473de8b111e69e8e02c82bb19d6-1744820641.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-ssh.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a7425d38ee8b111e69e8e02c82bb19d6-188589325.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev-proxy-tim.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dev3.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "diana.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "dickhannah.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "don.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "doncarro.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "doncarro2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "drivedavid.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "driveplanet.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "driversource.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "eaglerockindian.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "edmark.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "eliteauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "em.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "empress.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "epicfinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ewwylie-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ewwylie.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "expectant-test.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "faulkner-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "faulkner.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "fcf.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "fiesta.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "finance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "firstcredit.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "fischer.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "fjautogroup.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "florencetoyota.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "fugate.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "galeanakia.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "goschauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "goschauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "aea74a46f7dae11e79b4602c04bab068-621351362.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "grafana.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "grappone-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "grayson.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "gregsauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "greychevrolet.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "groppetti.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "group1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "grubbs.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "happytrailsrv.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "healthfair.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "help.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "helpcenter.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hennessy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hibbingchrysler.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hinesville.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hodge.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hopeful-test.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hornady.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hoskins.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "acbce84a17db511e79b4602c04bab068-1256703684.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hubot.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hudco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hudsonauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hudsonauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hudsondemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "hyrell.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ac6d46e727da611e789ef02133f294c6-1285731629.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "iflx-0.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ilendingdirec-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ilendingdirect.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "industrystandard.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "innovateauto-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "innovateauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "integrity.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "interactiveda-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "irving.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jamie.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jamintl-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jamintl.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jeff.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jeremy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jetskiofmiami.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jgr-inc.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jive.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "jmac.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "joe.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "joe1.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "joe2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "joeltest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "joetest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "john.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "52.42.208.184"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "k8s-dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "54.200.34.42"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "dev.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "54.202.1.180"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.dev.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.57.78"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.internal.dev.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.57.78"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-events-us-west-2a.internal.dev.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.57.78"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-us-west-2a.internal.dev.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "54.213.42.211"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.prod.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.40.224"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.internal.prod.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.40.224"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-events-us-west-2a.internal.prod.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.40.224"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-us-west-2a.internal.prod.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "54.202.158.64"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.44.43"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "api.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.44.43"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-events-us-west-2a.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.72.240"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "etcd-events-us-west-2b.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.111.18"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "etcd-events-us-west-2c.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.44.43"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "etcd-us-west-2a.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.72.240"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "etcd-us-west-2b.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "10.0.111.18"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "etcd-us-west-2c.internal.test.k8s.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "kendallauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "kenyonpowerboats.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ksw.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "kwesi.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ky2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "kynzie.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "kynzington.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lancebuick.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lawton.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lesterglenn.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lfs-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lfs.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "live.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lloydsplan.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "loanmart-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "loanmart.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lompochonda.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "lonestar.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "long.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "longmontford.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "louisville.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mahoneys.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mainstreet.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "majormotors.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marektest001.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marektest002.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marektest003.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mark.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marketingdemo-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marketingdemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "markmiller-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "markmillertoyota.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "marveldeals.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mas.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "matthewdemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mayflower.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mccarthygroup.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mcgeewm-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mcgrath.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mega.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "merrick2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "migrationtest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mileone-sandb-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mileone-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mileone-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mileone.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "modelfinancec-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "modelfinanceco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "modernfinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "momentum.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "moovel.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "mosaic.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "myautofocus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "myersrv.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "nac.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "naperville.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "napervillecaddy.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "nda.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "newport.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "nicholsmarine.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "nnacinc.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "northcoast.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "northtexas.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "oldballweg.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "oldcotruck.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "oldgrappone.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "oldsierracredit.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "opploans.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "owen.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "owentest-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "owentest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "owentestdefpe-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "owentestdefperms.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "35.190.41.101"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "packages.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "parasail.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "parks.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "patmillikan.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "patmilliken-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "patmilliken.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "peanutbutterco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "penskedemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "pensketruckdemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "perrybros.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "phase3dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "pierceyautogroup.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "poagecenter.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost3.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "poageplaza.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "premierautosales.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "prime-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "prime_sandbox-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "acc76b42f7db511e79b4602c04bab068-1967619701.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "printing-dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "acc564ff37db511e79b4602c04bab068-2072268941.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "printing.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a476463d6d3b911e69621023750e49fb-613861567.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "prometheus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a7e3d43797dae11e79b4602c04bab068-274950499.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "backend.prometheus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a448a95eb01fb11e7b6920265eb13f0e-1251747393.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "custom.prometheus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a7de09ae27dae11e79b4602c04bab068-402968325.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "frontend.prometheus.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "a7e65ac6e7dae11e79b4602c04bab068-666892800.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "pushgateway.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "qa.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "quirkcars-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "qvale.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ranchomotorco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ranchomotors.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "redlands.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "reineke-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "reineke.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "revolution.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ricart.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ridenow.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ridenow2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ridetime.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "road-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "robert.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "route44toyota.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "royal-phase3.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "royal-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "rtmotors.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "rudolph-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "rudolph.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "rusnak.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "rwmarine.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "safro.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "salestemplate.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sb-aagny.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sb-hudson.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sb-hudsonauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sb-scheduler-hudson.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sb-yarkauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "scheduler.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "schedulertest.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "schenn.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "serrausa-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "serrausa.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "servco-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "servco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "shane-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "shane.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "shelly.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "shelor.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sierra-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sierra.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sierracredit-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sierracredit.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "signature.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "simplefinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "simplefinanceco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "skillsoft.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "smg.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "socalpenske-s-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "socalpenske-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "socalpenske.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "spdtrucking-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "spdtrucking.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint10.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint11.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint12.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint13.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint14.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint15.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint16.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint17-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint17.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint18.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint19.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint20.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint21.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint22.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint23.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint25.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint26-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint26.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint27.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint28.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint29.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint30.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint31.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint5.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint8.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sprint9.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "accd8856a7db511e79b4602c04bab068-1326358080.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ssh-serer.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "accd8856a7db511e79b4602c04bab068-1326358080.us-west-2.elb.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "ssh-server.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "ec2-54-187-204-228.us-west-2.compute.amazonaws.com"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sso.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "staging.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "stevewhite.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "stevinson-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "support-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "support.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "sync.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "t-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidemos.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "tam-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidemos.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "tam.compligo.com.", 
+            "TTL": 600
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "target-dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "target-phase3-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "target-phase3-uat.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "target-uat-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "target-uat.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "tate.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "template-dev.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "template-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "template-uat-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "template-uat.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "template.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "test-ch6.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "35.190.21.74"
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "test123.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "35.190.31.183"
+                }
+            ], 
+            "Type": "A", 
+            "Name": "test456.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "testlocalphp.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "testlocalphp2.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "testreboot.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "testsprint26.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "thecargroup-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "thecargroup-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "thecargroup.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complidev1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "tim.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "timefinanceco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "tituswill-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "transamerica.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "uga.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "underriner-sb.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "unitedfinance.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "unitedfinanceco.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "universal.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "vachongroup.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "veros-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "victory.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost8.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "warrenhenry.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost7.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "westherr.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "what.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "wheels.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost5.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "wheelsdemo.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "compligo1.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "wv.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "wylietrucking.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "wyndham123.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost4.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "yarkauto-sandbox.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost2.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "yarkauto.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "zate.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "zeta.compligo.com.", 
+            "TTL": 300
+        }, 
+        {
+            "ResourceRecords": [
+                {
+                    "Value": "complihost6.matshost.co.uk."
+                }
+            ], 
+            "Type": "CNAME", 
+            "Name": "zt.compligo.com.", 
+            "TTL": 300
+        }
+    ]
+}

--- a/main.go
+++ b/main.go
@@ -43,7 +43,6 @@ func (e *excludesT) Len() int {
 func (e *excludesT) Contains(value string) bool {
 	i := sort.SearchStrings(*e, value)
 	if i < len(*e) && (*e)[i] == value {
-		//log.Printf("%s found \"%s\" at excludes[%d]\n", value, *e, i)
 		return true
 	}
 	return false

--- a/main.go
+++ b/main.go
@@ -209,7 +209,6 @@ func main() {
 			if err != nil {
 				panic(err)
 			}
-			log.Printf("%v", recordSet)
 			recordSets = append(recordSets, recordSet...)
 		}
 	} else {

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/route53"
 )
 
-var version, dry, help bool
+var version, dry, help, showChanges bool
 
 type excludesT []string
 
@@ -104,10 +104,10 @@ func getResourceRecords(profile string, domain string) ([]*route53.ResourceRecor
 	return rrsets, nil
 }
 
-func getResourceRecordsFromHostedZoneId(profile string, hostedZoneId string) ([]*route53.ResourceRecordSet, error) {
+func getResourceRecordsFromHostedZoneID(profile string, hostedZoneID string) ([]*route53.ResourceRecordSet, error) {
 	service := connect(profile)
 	params := &route53.ListResourceRecordSetsInput{
-		HostedZoneId: aws.String(hostedZoneId),
+		HostedZoneId: aws.String(hostedZoneID),
 	}
 	var rrsets []*route53.ResourceRecordSet
 	for {
@@ -157,6 +157,7 @@ func updateRecords(sourceProfile, destProfile, domain string, changes []*route53
 	service := connect(destProfile)
 	zone, err := getHostedZone(service, domain)
 	if err != nil {
+		log.Printf("failed to get hosted zone")
 		return nil, err
 	}
 	params := &route53.ChangeResourceRecordSetsInput{
@@ -170,9 +171,70 @@ func updateRecords(sourceProfile, destProfile, domain string, changes []*route53
 	return resp.ChangeInfo, nil
 }
 
+func executeChange(sourceProfile, destProfile, domain string, changes []*route53.Change) (*route53.ChangeInfo, error) {
+	changeInfo, err := updateRecords(sourceProfile, destProfile, domain, changes)
+	if err != nil {
+		log.Printf("Failed to update records")
+		return nil, err
+	}
+	if changeInfo != nil {
+		log.Printf("%d records in '%s' are copied from %s to %s\n",
+			len(changes), domain, sourceProfile, destProfile)
+		log.Printf("%#v\n", changeInfo)
+	} else {
+		log.Printf("Something went wrong!  Change info was nil.")
+	}
+	return nil, nil
+}
+
+func processChangeBatch(sourceProfile, destProfile, domain string, changes []*route53.Change) (*route53.ChangeInfo, error) {
+
+	var changeInfo *route53.ChangeInfo
+	var err error
+
+	// AWS route53 treats each chnage as 2 requests
+	// No more than 1000 requests may be processed at a time
+	total := len(changes) * 2
+	var batches int
+	if total > 1000 {
+		if total%1000 != 0 {
+			batches = (total / 1000) + 1
+		} else {
+			batches = total / 1000
+		}
+		log.Printf("Processing changes in %d batches", batches)
+		var start, end int
+		for i := 0; i < batches; i++ {
+			if i < 1 {
+				start = i
+			} else {
+				start = i * (1000 / 2)
+			}
+			if i+1 == batches {
+				end = start + (total / 2)
+			} else {
+				end = start + (1000 / 2)
+			}
+			log.Printf("Processing changes %d through %d", start, end)
+			changeInfo, err = executeChange(sourceProfile, destProfile, domain, changes[start:end])
+			if err != nil {
+				return nil, err
+			}
+			total = total - (end * 2)
+		}
+	} else {
+		changeInfo, err = executeChange(sourceProfile, destProfile, domain, changes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return changeInfo, nil
+}
+
 func init() {
 	flag.BoolVar(&dry, "dry", false, "Don't make any changes")
 	flag.BoolVar(&help, "help", false, "Show help text")
+	flag.BoolVar(&showChanges, "show-changes", false, "Show change list")
 	flag.BoolVar(&version, "version", false, "Show version")
 	flag.Var(&exclude, "exclude", "Comma separated list of DNS entries types of the base domain to be ignored. If not set SOA and NS will be excluded.")
 	flag.StringVar(&hostedZones, "hosted-zones", "", "Comma separated lsit of hosted-zones for accounts with access limmited to specific hosted zones")
@@ -228,11 +290,11 @@ func main() {
 
 	if len(hostedZonesArray) > 0 && len(hostedZonesArray) < 2 {
 		hostedZone := string(hostedZonesArray[0])
-		recordSets, err = getResourceRecordsFromHostedZoneId(sourceProfile, hostedZone)
+		recordSets, err = getResourceRecordsFromHostedZoneID(sourceProfile, hostedZone)
 	} else if len(hostedZonesArray) > 1 {
 		for i := 0; i < len(hostedZonesArray); i++ {
 			hostedZone := string(hostedZonesArray[i])
-			recordSet, err := getResourceRecordsFromHostedZoneId(sourceProfile, hostedZone)
+			recordSet, err := getResourceRecordsFromHostedZoneID(sourceProfile, hostedZone)
 			if err != nil {
 				panic(err)
 			}
@@ -248,6 +310,10 @@ func main() {
 	changes := createChanges(srcDomain, destDomain, recordSets)
 	log.Println("Number of records to copy", len(changes))
 
+	if showChanges {
+		log.Printf("%#v\n", changes)
+	}
+
 	if dry {
 		log.Printf("Not copying records to %s since -dry is given\n", destProfile)
 		service := connect(destProfile)
@@ -258,13 +324,7 @@ func main() {
 		log.Printf("Destination profile contains %d records, including NS and SOA\n",
 			*zone.ResourceRecordSetCount)
 	} else {
-		changeInfo, err := updateRecords(sourceProfile, destProfile, destDomain, changes)
-		if err != nil {
-			panic(err)
-		}
-		log.Printf("%d records in '%s' are copied from %s to %s\n",
-			len(changes), destDomain, sourceProfile, destProfile)
-		log.Printf("%#v\n", changeInfo)
+		processChangeBatch(sourceProfile, destProfile, destDomain, changes)
 	}
 
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	//"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -197,11 +196,6 @@ func main() {
 	var hostedZonesArray []string
 
 	if len(hostedZones) > 0 {
-		/*
-			err := json.Unmarshal([]byte(hostedZones), &hostedZonesArray)
-			if err != nil {
-				panic(err)
-			}*/
 		for _, t := range strings.Split(hostedZones, ",") {
 			hostedZonesArray = append(hostedZonesArray, t)
 		}

--- a/main.go
+++ b/main.go
@@ -196,22 +196,21 @@ func main() {
 	var hostedZonesArray []string
 
 	if len(hostedZones) > 0 {
-		for _, t := range strings.Split(hostedZones, ",") {
-			hostedZonesArray = append(hostedZonesArray, t)
-		}
-
+		hostedZonesArray = strings.Split(hostedZones, ",")
 	}
 
 	if len(hostedZonesArray) > 0 && len(hostedZonesArray) < 2 {
-		recordSets, err = getResourceRecordsFromHostedZoneId(sourceProfile, hostedZones)
-	} else if len(hostedZonesArray) > 2 {
+		hostedZone := string(hostedZonesArray[0])
+		recordSets, err = getResourceRecordsFromHostedZoneId(sourceProfile, hostedZone)
+	} else if len(hostedZonesArray) > 1 {
 		for i := 0; i < len(hostedZonesArray); i++ {
 			hostedZone := string(hostedZonesArray[i])
 			recordSet, err := getResourceRecordsFromHostedZoneId(sourceProfile, hostedZone)
 			if err != nil {
 				panic(err)
 			}
-			recordSets = append(recordSets, recordSet[0])
+			log.Printf("%v", recordSet)
+			recordSets = append(recordSets, recordSet...)
 		}
 	} else {
 		recordSets, err = getResourceRecords(sourceProfile, srcDomain)
@@ -222,6 +221,7 @@ func main() {
 
 	changes := createChanges(srcDomain, destDomain, recordSets)
 	log.Println("Number of records to copy", len(changes))
+	log.Printf("%v", changes)
 
 	if dry {
 		log.Printf("Not copying records to %s since -dry is given\n", destProfile)

--- a/main.go
+++ b/main.go
@@ -220,7 +220,6 @@ func main() {
 
 	changes := createChanges(srcDomain, destDomain, recordSets)
 	log.Println("Number of records to copy", len(changes))
-	log.Printf("%v", changes)
 
 	if dry {
 		log.Printf("Not copying records to %s since -dry is given\n", destProfile)

--- a/main.go
+++ b/main.go
@@ -80,11 +80,26 @@ func getResourceRecords(profile string, domain string) ([]*route53.ResourceRecor
 	params := &route53.ListResourceRecordSetsInput{
 		HostedZoneId: aws.String(*zone.Id),
 	}
-	resp, err := service.ListResourceRecordSets(params)
-	if err != nil {
-		return nil, err
+	var rrsets []*route53.ResourceRecordSet
+
+	for {
+		var resp *route53.ListResourceRecordSetsOutput
+		resp, err = service.ListResourceRecordSets(params)
+
+		if err != nil {
+			return nil, err
+		}
+
+		rrsets = append(rrsets, resp.ResourceRecordSets...)
+		if *resp.IsTruncated {
+			params.StartRecordName = resp.NextRecordName
+			params.StartRecordType = resp.NextRecordType
+			params.StartRecordIdentifier = resp.NextRecordIdentifier
+		} else {
+			break
+		}
 	}
-	return resp.ResourceRecordSets, nil
+	return rrsets, nil
 }
 
 func createChanges(srcDomain string, destDomain string, recordSets []*route53.ResourceRecordSet) []*route53.Change {

--- a/main_test.go
+++ b/main_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestMain(t *testing.T) {
-	actual := Main()
+	actual := main()
 	expected := "main"
 	if actual != expected {
 		t.Errorf("main(): %v, expected %v", actual, expected)

--- a/version.go
+++ b/version.go
@@ -1,3 +1,4 @@
 package main
 
-const Version = "v1.1.1"
+// Version of this app
+const Version = "v2.0.0"


### PR DESCRIPTION
This PR adds support for specifying the hosted zone id and adds support for sending more than 1000 requests (500 resource records).  In some cases, a user may only be able to access one aws hosted zone on an account.  Additionally, this PR pulls in changes from two other PRs from ordis and pcorliss to add support for pagination, and NS/SOA exclusion.